### PR TITLE
Prevent contracts from being re-initialized

### DIFF
--- a/token/src/storage_types.rs
+++ b/token/src/storage_types.rs
@@ -25,7 +25,6 @@ pub struct AllowanceValue {
 pub enum DataKey {
     Allowance(AllowanceDataKey),
     Balance(Address),
-    Nonce(Address),
     State(Address),
     Admin,
 }

--- a/upgradeable_contract/new_contract/src/lib.rs
+++ b/upgradeable_contract/new_contract/src/lib.rs
@@ -22,7 +22,7 @@ pub struct UpgradeableContract;
 impl UpgradeableContract {
     pub fn init(e: Env, admin: Address) -> Result<(), Error> {
         if e.storage().instance().has(&DataKey::Admin) {
-            return Err(Error::AlreadyInitialized)
+            return Err(Error::AlreadyInitialized);
         }
         e.storage().instance().set(&DataKey::Admin, &admin);
         Ok(())

--- a/upgradeable_contract/new_contract/src/lib.rs
+++ b/upgradeable_contract/new_contract/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, Address, BytesN, Env};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, BytesN, Env};
 
 #[contracttype]
 #[derive(Clone)]
@@ -8,13 +8,24 @@ enum DataKey {
     Admin,
 }
 
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    AlreadyInitialized = 1,
+}
+
 #[contract]
 pub struct UpgradeableContract;
 
 #[contractimpl]
 impl UpgradeableContract {
-    pub fn init(e: Env, admin: Address) {
+    pub fn init(e: Env, admin: Address) -> Result<(), Error> {
+        if e.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::AlreadyInitialized)
+        }
         e.storage().instance().set(&DataKey::Admin, &admin);
+        Ok(())
     }
 
     pub fn version() -> u32 {

--- a/upgradeable_contract/old_contract/src/lib.rs
+++ b/upgradeable_contract/old_contract/src/lib.rs
@@ -22,7 +22,7 @@ pub struct UpgradeableContract;
 impl UpgradeableContract {
     pub fn init(e: Env, admin: Address) -> Result<(), Error> {
         if e.storage().instance().has(&DataKey::Admin) {
-            return Err(Error::AlreadyInitialized)
+            return Err(Error::AlreadyInitialized);
         }
         e.storage().instance().set(&DataKey::Admin, &admin);
         Ok(())

--- a/upgradeable_contract/old_contract/src/lib.rs
+++ b/upgradeable_contract/old_contract/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, Address, BytesN, Env};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, BytesN, Env};
 
 #[contracttype]
 #[derive(Clone)]
@@ -8,13 +8,24 @@ enum DataKey {
     Admin,
 }
 
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    AlreadyInitialized = 1,
+}
+
 #[contract]
 pub struct UpgradeableContract;
 
 #[contractimpl]
 impl UpgradeableContract {
-    pub fn init(e: Env, admin: Address) {
+    pub fn init(e: Env, admin: Address) -> Result<(), Error> {
+        if e.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::AlreadyInitialized)
+        }
         e.storage().instance().set(&DataKey::Admin, &admin);
+        Ok(())
     }
 
     pub fn version() -> u32 {

--- a/upgradeable_contract/old_contract/src/test.rs
+++ b/upgradeable_contract/old_contract/src/test.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
-use soroban_sdk::{testutils::Address as _, Address, BytesN, Env};
 use crate::Error;
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env};
 
 mod old_contract {
     soroban_sdk::contractimport!(

--- a/upgradeable_contract/old_contract/src/test.rs
+++ b/upgradeable_contract/old_contract/src/test.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use soroban_sdk::{testutils::Address as _, Address, BytesN, Env};
-use super::*;
+use crate::Error;
 
 mod old_contract {
     soroban_sdk::contractimport!(

--- a/upgradeable_contract/old_contract/src/test.rs
+++ b/upgradeable_contract/old_contract/src/test.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 
 use soroban_sdk::{testutils::Address as _, Address, BytesN, Env};
+use super::*;
 
 mod old_contract {
     soroban_sdk::contractimport!(
@@ -46,8 +47,7 @@ fn test() {
 }
 
 #[test]
-#[should_panic(expected = "HostError: Error(Contract, #1)")]
-fn test_panic() {
+fn test_cannot_re_init() {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -58,6 +58,5 @@ fn test_panic() {
     let client = old_contract::Client::new(&env, &contract_id);
     let admin = Address::generate(&env);
     client.init(&admin);
-
-    client.init(&admin);
+    assert_eq!(client.try_init(&admin), Err(Ok(Error::AlreadyInitialized)));
 }

--- a/upgradeable_contract/old_contract/src/test.rs
+++ b/upgradeable_contract/old_contract/src/test.rs
@@ -54,9 +54,15 @@ fn test_cannot_re_init() {
     // Note that we use register_contract_wasm instead of register_contract
     // because the old contracts WASM is expected to exist in storage.
     let contract_id = env.register_contract_wasm(None, old_contract::WASM);
-
     let client = old_contract::Client::new(&env, &contract_id);
     let admin = Address::generate(&env);
     client.init(&admin);
-    assert_eq!(client.try_init(&admin), Err(Ok(Error::AlreadyInitialized)));
+
+    // `try_init` is expected to return an error. Since client is generated from Wasm,
+    // this is a generic SDK error.
+    let err: soroban_sdk::Error = client.try_init(&admin).err().unwrap().unwrap();
+    // Convert the SDK error to the contract error.
+    let contract_err: Error = err.try_into().unwrap();
+    // Make sure contract error has the expected value.
+    assert_eq!(contract_err, Error::AlreadyInitialized);
 }

--- a/upgradeable_contract/old_contract/src/test.rs
+++ b/upgradeable_contract/old_contract/src/test.rs
@@ -44,3 +44,20 @@ fn test() {
     let client = new_contract::Client::new(&env, &contract_id);
     assert_eq!(1010101, client.new_v2_fn());
 }
+
+#[test]
+#[should_panic(expected = "HostError: Error(Contract, #1)")]
+fn test_panic() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    // Note that we use register_contract_wasm instead of register_contract
+    // because the old contracts WASM is expected to exist in storage.
+    let contract_id = env.register_contract_wasm(None, old_contract::WASM);
+
+    let client = old_contract::Client::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+
+    client.init(&admin);
+}


### PR DESCRIPTION
### What

Prevent the init function front being executed after the contract has already been initialized.

### Why

Incorporating a security feature to prevent adversaries from substituting the admin by invoking the init function, enabling them to upgrade the contract to a malicious version. This fix prevents anyone copying the upgrade functionality from replicating this vulnerability in their contracts.

### Known limitations

N/A
